### PR TITLE
docs: lock Sprint 1 goals and Sprint 0 retrospective

### DIFF
--- a/dev_log/develop.md
+++ b/dev_log/develop.md
@@ -20,3 +20,13 @@
 1. Raylib vs SFML vs SDL2+Dear ImGui – which ecosystem are you most comfortable with?
 2. How many ants do you personally want to see on screen before it feels “alive”? (this drives grid size vs detail trade-off)
 3. Real-time vs turn-based: do we advance simulation every frame (true real-time) or in fixed 0.1 s ticks for determinism?
+
+## Sprint 0 Retrospective – Decisions Locked (Nov 19, 2025)
+
+- Compiler: LLVM Clang 21.1.5 (primary) + MSVC fallback for faster Windows builds
+- Build: CMake + Ninja (preferred) / Visual Studio generator (current working)
+- Graphics: Raylib 5.6-dev confirmed — zero dependencies, perfect Pi5 support
+- Asset pipeline: Post-build copy via $<TARGET_FILE_DIR> — works across generators
+- Branching: GitFlow (main = golden releases, develop = integration)
+- First green executable achieved with real ant.png sprite
+- Lesson learned: Windows toolchain is spicy — hybrid MSVC/Clang workflow adopted

--- a/dev_log/master_plan.md
+++ b/dev_log/master_plan.md
@@ -20,3 +20,21 @@
 1. Raylib vs SFML vs SDL2+Dear ImGui – which ecosystem are you most comfortable with?
 2. How many ants do you personally want to see on screen before it feels “alive”? (this drives grid size vs detail trade-off)
 3. Real-time vs turn-based: do we advance simulation every frame (true real-time) or in fixed 0.1 s ticks for determinism?
+
+## Milestone Roadmap (updated Nov 19, 2025)
+
+1. Sprint 0 – Brainstorm & Docs ✓ (Nov 18–19)
+2. Sprint 1 – Pheromone-Driven Foraging MVP (Nov 19–30)
+   - Evaporating pheromone grids (food + home)
+   - Mouse-paintable trails for instant feedback
+   - 1–10 ants with sensing, laying, food pickup/dropoff
+   - Visible recruitment → highway formation
+   - Success = “holy shit, they’re organizing themselves” moment
+3. Sprint 2 – Nest Arena + Digging Substrate (Dec 1–15)
+   - Second connected arena
+   - Queen, nurses, egg chambers
+   - Worker excavation triggered by overcrowding pheromone
+4. Sprint 3 – Task Allocation & Castes (Dec)
+5. Sprint 4 – Polish, Animation, Sound, Save/Load
+6. Sprint 5 – Raspberry Pi 5 Port + Touch UI
+7. Sprint 6+ – Hardware Bring-Up, Kickstarter Prep


### PR DESCRIPTION
- Pheromone foraging MVP defined and scheduled
- Historical decisions recorded for future maintainers
- No scope creep — digging/queen deferred to Sprint 2+